### PR TITLE
Exit Codes and Promises

### DIFF
--- a/bin/hipchat-hotline
+++ b/bin/hipchat-hotline
@@ -36,5 +36,25 @@ if (wantVersion(argv)) {
   process.exit(1);
 }
 
+function printSuccess(result) {
+  console.log('Message Sent.');
+  if (result && result.length && result.length !== 0) {
+    console.log(result);
+  }
+}
+
+function printError(e) {
+  console.log('Error:');
+  if (e) {
+    console.log(e.message ? e.message : e);
+  }
+}
+
 require('../index')
-  .hotline(process.env, process.argv);
+  .hotline(process.env, process.argv)
+  .done(function(result) {
+    printSuccess(result);
+  }, function(e) {
+    printError(e);
+    process.exit(1);
+  });

--- a/lib/hip-client.js
+++ b/lib/hip-client.js
@@ -7,11 +7,8 @@
 //
 var debug = require('debug')('hip-client'),
     extend = require('amp-extend'),
-    HipChatter = require('hipchatter');
-
-function HipClient(token) {
-  this.hipchatter = new HipChatter(token);
-}
+    HipChatter = require('hipchatter'),
+    P = require('bluebird');
 
 var debugBeforeSend = function(fnName, recipient, content, options) {
   debug(fnName);
@@ -20,44 +17,51 @@ var debugBeforeSend = function(fnName, recipient, content, options) {
   debug('options');
   debug(options);
 };
+
+function sendMessage(chatter, type, to, msg, opts) {
+  return new P(function(resolve, reject) {
+    var resolver = function(err, res) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    };
+    var options = extend({ message: msg }, opts);
+    debugBeforeSend('send' + type + 'Message', to, msg, options);
+    if (type == 'User') {
+      chatter.send_private_message(to, options, resolver);
+    } else {
+      chatter.notify(to, options, resolver);
+    }
+  });
+}
+
+/**
+ * Binds together a token and a HipChatter instance.
+ */
+function HipClient(token) {
+  this.hipchatter = new HipChatter(token);
+}
+
 /**
  * This function is responsible for invoking the API described here:
  * https://www.hipchat.com/docs/apiv2/method/private_message_user
  */
-HipClient.prototype.sendUserMessage =
-  function(user, content, options, callback) {
-    var optionsToUse = extend({ message: content }, options);
-    debugBeforeSend('sendUserMessage', user, content, optionsToUse);
-    this.hipchatter.send_private_message(user, optionsToUse, callback);
-  };
+HipClient.prototype.sendUserMessage = function(to, msg, opts) {
+  return sendMessage(this.hipchatter, 'User', to, msg, opts);
+};
 
 /**
  * This function is responsible for invoking the API described here:
  * https://www.hipchat.com/docs/apiv2/method/send_room_notification
  */
-HipClient.prototype.sendRoomMessage =
-  function(room, content, options, callback) {
-    var optionsToUse = extend({ message: content }, options);
-    debugBeforeSend('sendRoomMessage', room, content, optionsToUse);
-    this.hipchatter.notify(room, optionsToUse, callback);
-  };
-
-function stdoutCallback(err) {
-  if (err) {
-    console.log('Problem: ' + err);
-  }
-}
+HipClient.prototype.sendRoomMessage = function(to, msg, opts) {
+  return sendMessage(this.hipchatter, 'Room', to, msg, opts);
+};
 
 function client(token) {
-  var hipClient = new HipClient(token);
-  return {
-    sendUserMessage: function(user, content, options) {
-      hipClient.sendUserMessage(user, content, options, stdoutCallback);
-    },
-    sendRoomMessage: function(room, content, options) {
-      hipClient.sendRoomMessage(room, content, options, stdoutCallback);
-    }
-  };
+  return new HipClient(token);
 }
 
 exports.client = client;

--- a/lib/hipchat-hotline.js
+++ b/lib/hipchat-hotline.js
@@ -26,15 +26,15 @@ function sendMessage(client, argv) {
   debug('Options: ');
   debug(options);
   if (intended.recipientType() == 'user') {
-    client.sendUserMessage(recipient, content, options);
+    return client.sendUserMessage(recipient, content, options);
   } else {
-    client.sendRoomMessage(recipient, content, options);
+    return client.sendRoomMessage(recipient, content, options);
   }
 }
 
 function hotline(env, argv) {
   var token = getTokenOrDie(env);
-  sendMessage(client(token), argv);
+  return sendMessage(client(token), argv);
 }
 
 exports.hotline = hotline;

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   "dependencies": {
     "amp-extend": "^1.0.1",
     "amp-reduce": "^1.0.0",
+    "bluebird": "^2.9.13",
     "debug": "^2.1.1",
     "hipchatter": "^0.2.0",
     "minimist": "^1.1.0"

--- a/test/lib/hip-client-spec.js
+++ b/test/lib/hip-client-spec.js
@@ -1,57 +1,114 @@
 var rewire = require('rewire'),
     extend = require('amp-extend');
 
-var hipClientModule = rewire('../../lib/hip-client');
-var client = hipClientModule.client;
-
 describe('hip-client', function() {
+  describe('passing messages to hipchatter client', function() {
 
-  var injectedConstructor = function() {
-    return mockHipChatterInstance;
-  };
+    // Methods aren't important here-- instead this is created so that
+    // we have something to spy on.
+    var mockHipChatterInstance = {
+      send_private_message: function() {},
+      notify: function() {}
+    };
 
-  hipClientModule.__set__('HipChatter', injectedConstructor);
+    var injectedConstructor = function() {
+      return mockHipChatterInstance;
+    };
 
-  var mockHipChatterInstance = {
-    send_private_message: function() {},
-    notify: function() {}
-  };
+    var hipClientModule = rewire('../../lib/hip-client');
+    var client = hipClientModule.client;
 
-  var hipClient = client('UNIMPORTANT_API_TOKEN');
+    hipClientModule.__set__('HipChatter', injectedConstructor);
 
-  var exampleUser = 'exampleUser',
-      exampleRoom = 'exampleRoom',
-      exampleOptions = {
-        'message_format': 'text',
-        'notify': false
-      },
-      exampleMessage = 'sampleMessage';
+    var hipClient = client('UNIMPORTANT_API_TOKEN');
 
-  describe('sendUserMessage', function() {
-    it('works with HipChatter#send_private_message', function() {
-      spyOn(mockHipChatterInstance, 'send_private_message');
-      hipClient.sendUserMessage(exampleUser, exampleMessage, exampleOptions);
-      var expectedOptions = extend({},
-                                   { 'message': exampleMessage },
-                                   exampleOptions);
-      expect(mockHipChatterInstance.send_private_message)
-        .toHaveBeenCalledWith(exampleUser,
-                              expectedOptions,
-                              jasmine.any(Function));
+    var exampleUser = 'exampleUser',
+        exampleRoom = 'exampleRoom',
+        exampleOptions = {
+          'message_format': 'text',
+          'notify': false
+        },
+        exampleMessage = 'sampleMessage';
+
+    describe('sendUserMessage', function() {
+      it('works with HipChatter#send_private_message', function() {
+        spyOn(mockHipChatterInstance, 'send_private_message');
+        hipClient.sendUserMessage(exampleUser, exampleMessage, exampleOptions);
+        var expectedOptions = extend({},
+                                     { 'message': exampleMessage },
+                                     exampleOptions);
+        expect(mockHipChatterInstance.send_private_message)
+          .toHaveBeenCalledWith(exampleUser,
+                                expectedOptions,
+                                jasmine.any(Function));
+      });
+    });
+
+    describe('sendRoomMessage', function() {
+      it('works with HipChatter#notify', function() {
+        spyOn(mockHipChatterInstance, 'notify');
+        hipClient.sendRoomMessage(exampleRoom, exampleMessage, exampleOptions);
+        var expectedOptions = extend({},
+                                     { 'message': exampleMessage },
+                                     exampleOptions);
+        expect(mockHipChatterInstance.notify)
+          .toHaveBeenCalledWith(exampleRoom,
+                                expectedOptions,
+                                jasmine.any(Function));
+      });
     });
   });
 
-  describe('sendRoomMessage', function() {
-    it('works with HipChatter#notify', function() {
-      spyOn(mockHipChatterInstance, 'notify');
-      hipClient.sendRoomMessage(exampleRoom, exampleMessage, exampleOptions);
-      var expectedOptions = extend({},
-                                   { 'message': exampleMessage },
-                                   exampleOptions);
-      expect(mockHipChatterInstance.notify)
-        .toHaveBeenCalledWith(exampleRoom,
-                              expectedOptions,
-                              jasmine.any(Function));
+  describe('resolution + rejection of returned promises', function() {
+
+    // Methods are important here-- one pretends the HipChatter
+    // invocation always fails, the other always succeeds.
+    var error = new Error('Failure'),
+        successfulResponse = '',
+        alwaysFails = function(to, opts, callback) {
+          callback(error);
+        },
+        alwaysSucceeds = function(to, opts, callback) {
+          callback(null, successfulResponse);
+        },
+        mockHipChatterInstance = {
+          // sendUserMessage
+          send_private_message: alwaysFails,
+          // sendRoomMessage
+          notify: alwaysSucceeds
+        },
+        injectedConstructor = function() {
+          return mockHipChatterInstance;
+        },
+        hipClientModule = rewire('../../lib/hip-client'),
+        client = hipClientModule.client;
+
+    hipClientModule.__set__('HipChatter', injectedConstructor);
+
+    var hipClient = client('UNIMPORTANT_API_TOKEN');
+
+    describe('successful resolution', function() {
+      it('returns the response from HipChatter', function() {
+        hipClient
+          .sendRoomMessage('to', 'msg', {})
+          .done(function(result) {
+            expect(result).toEqual(successfulResponse);
+          }, function() {
+            expect(true).toEqual(false);
+          });
+      });
+    });
+
+    describe('unsuccessful rejection', function() {
+      it('returns the Error from HipChatter', function() {
+        hipClient
+          .sendUserMessage('to', 'msg', {})
+          .done(function() {
+            expect(true).toEqual(false);
+          }, function(error) {
+            expect(error).toEqual(error);
+          });
+      });
     });
   });
 });


### PR DESCRIPTION
This should fix #4.

It does so by making things promise based.

This allows the executing script to set the exit code.

Specs around the promises were the missing link between "100%".
